### PR TITLE
Issue template newlines

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,20 +7,20 @@ assignees: ''
 
 ---
 
-**Describe the bug**
+**Describe the bug**\
 A clear and concise description of what the bug is.
 
-**To Reproduce**
+**To Reproduce**\
 Steps to reproduce the behavior:
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-**Expected behavior**
+**Expected behavior**\
 A clear and concise description of what you expected to happen.
 
-**Screenshots**
+**Screenshots**\
 If applicable, add screenshots to help explain your problem.
 
 **Environment:**
@@ -29,5 +29,5 @@ If applicable, add screenshots to help explain your problem.
  - Branch (only if you used a different branch than main/master) [e.g. some-branch-name]
 - Changes (state any unofficial changes you made yourself) [e.g. I removed the emotion on line 130 from data.json]
 
-**Additional context**
+**Additional context**\
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/collaborator_application.md
+++ b/.github/ISSUE_TEMPLATE/collaborator_application.md
@@ -9,10 +9,10 @@ assignees: ''
 
 Describe here why you should be a collaborator.
 
-**Your past contributions:**
+**Your past contributions:**\
 List of your past contributions and changes to this project.
 - I did this
 - I did that
 
-**Experience and skills**
+**Experience and skills**\
 What are your skills and past experiences?

--- a/.github/ISSUE_TEMPLATE/community_guidelines.md
+++ b/.github/ISSUE_TEMPLATE/community_guidelines.md
@@ -7,8 +7,8 @@ assignees: ''
 
 ---
 
-**Violation type**
+**Violation type**\
 What guideline did someone violate?
 
-**People**
+**People**\
 A person or people who have violated the guidelines.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,14 +7,14 @@ assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
+**Is your feature request related to a problem? Please describe.**\
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
-**Describe the solution you'd like**
+**Describe the solution you'd like**\
 A clear and concise description of what you want to happen.
 
-**Describe alternatives you've considered**
+**Describe alternatives you've considered**\
 A clear and concise description of any alternative solutions or features you've considered.
 
-**Additional context**
+**Additional context**\
 Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/vulnerability_report.md
+++ b/.github/ISSUE_TEMPLATE/vulnerability_report.md
@@ -7,30 +7,30 @@ assignees: ''
 
 ---
 
-**Describe the vulnerability**
+**Describe the vulnerability**\
 A clear and concise description of what the vulnerability is.
 
-**Environment:**
+**Environment:**\
 Under which conditions and in which environment does the vulnerability apply.
 - OS: [e.g. Windows]
 - Branch (only if you used a different branch than main/master) [e.g. some-branch-name]
 - Versions of included programs (Python, PyYaml, PyTest, etc.) 
 
-**Exploit**
+**Exploit**\
 Steps to exploit/use the vulnerability:
 1. Go to '...'
 2. Click on '....'
 3. Run '....'
 4. Access '....' 
 
-**Result**
+**Result**\
 What happens when someone uses the vulnerability. All the damage made, access gained by the attacker, etc.
 
-**Fix**
+**Fix**\
 Describe how we can fix the problem (if you know the solution).
 
-**Screenshots**
+**Screenshots**\
 If applicable, add screenshots to help explain your problem.
 
-**Additional context**
+**Additional context**\
 Add any other context about the problem here.


### PR DESCRIPTION
I added additional lines (with the "\" character) to issue templates in order to make them look better and more organized.

## Change overview
- added new lines into the issue templates

## Change type
- [ ] Bug fix
- [x] Feature
- [ ] Documentation update
- [ ] Test update
- [x] GitHub config files, templates, etc.

## Checklist
- [x] My code is properly formatted and styled (indentation, naming conventions, unused code/content, ...)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My change doesn't have any intentional vulnerable, malicious, malfunctioning, breaking, harmful and destructive content

## Contributors
- @VladislavKorecky 
